### PR TITLE
Restrict extension for Lite plan or above

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,31 +7,22 @@
 
 DeepScan is a cutting-edge JavaScript code inspection tool that helps you to find bugs and quality issues more precisely by data-flow analysis. You can also use it for React and Vue.js because DeepScan delivers [React specialized rules](https://deepscan.io/docs/rules/#react) and [Vue.js specialized rules](https://deepscan.io/docs/rules/#vue).
 
-**Note 1:** File Transfer
->
-> To use this extension, you should confirm that your code is transferred to the DeepScan server for inspection when you save your changes.
-> You can confirm it by pressing the Confirm button that appears when restarting VS Code after the installation.
->
-> Note that your code is completely deleted from the server right after the inspection.
-
-**Note 2:** DeepScan Access Token
->
-> An access token is required for transferring code and receiving inspection results.
-> DeepScan server uses the token to provide reliable and prompt inspection of your code.
->
-> Follow [instructions](https://deepscan.io/docs/deepscan/vscode#token) at DeepScan site to generate an access token for free.
-
-**Note 3:** Limitation of Analysis
->
-> The analysis is only per the transferred file. Some rules requiring inter-module information, such as [REACT_MISMATCHED_TYPE_OF_PROP](https://deepscan.io/docs/rules/react-mismatched-type-of-prop), does not apply in this plugin. To fully make use of DeepScan, please check out [Embedded Mode](#embedded-mode).
+**Note**: DeepScan Lite plan or above is needed to use this extension. Visit [deepscan.io](https://deepscan.io/pricing) to gain access to a 14-day free trial.
 
 ![Navigation](client/resources/preview.png)
 
-## How it works
+## How It Works
 
 - Report issues in Problems panel when you open a `*.js`, `*.jsx`, `*.mjs`, `*.ts`, `*.tsx`, and `*.vue` file and save it.
 - Highlight issues in the code.
 - Show a rule description using a code action. When you click the light bulb of the issue, you can see the detailed description of the rule and grasp what's the problem.
+
+## File Transfer
+
+To use this extension, you should confirm that your code is transferred to the DeepScan server for inspection when you save your changes.
+You can confirm it by pressing the Confirm button that appears when restarting VS Code after the installation.
+
+Note that your code is completely deleted from the server right after the inspection.
 
 ## DeepScan Access Token
 
@@ -42,8 +33,6 @@ For managing access token, this extension contributes the following commands to 
 - **Configure Access Token**: register the token generated at the DeepScan site.
 - **Delete Access Token**: remove the currently registered token from VS Code. (The token at the server remains unaffected.)
 - **Show Access Token Info**: display the name and expiration date of the current token.
-
-**Note:** Access token is not needed in [Embedded Mode](#embedded-mode).
 
 ## Settings Options
 
@@ -97,35 +86,7 @@ By **Ignore this line** and **Ignore this rule** code actions, you can add an in
 
 Read more about it [here](https://deepscan.io/docs/get-started/disabling-rules/).
 
-## Embedded Mode
-
-**Note:** This is a premium feature.
->
-> DeepScan supports an embedded mode, which works standalone without DeepScan server. It works with the local language server so you can:
-> * never worry about transferring the code outside.
-> * analyze a whole project rather than a file.
->
-> To activate this, contact us at [support@deepscan.io](mailto:support@deepscan.io).
-
-In the embedded mode, this extension contributes the following commands to the Command Palette:
-
-- **Inspect Project**: inspect the current project.
-- **Clear Project Problems**: clear inspected problems.
-
-### ESLint Analysis
-Run ESLint. You can see the ESLint alarms with DeepScan's.
-
-[eslint package](https://www.npmjs.com/package/eslint) is required in the local or global. Note that `NODE_PATH` environment variable is necessary to load the `eslint` module installed in global.
-
-It directly uses the package so your custom configurations and plugins are applied as is.
-
-- `deepscan.serverEmbedded.eslint.enable`: enable/disable ESLint analysis.
-- `deepscan.serverEmbedded.eslint.merge`: option for how identical issues of DeepScan and ESLint are merged. (defaults to `deepscan`)
-  * `deepscan`: show only DeepScan issues.
-  * `eslint`: show only ESLint issues.
-  * `both`: show all issues as is.
-
-## Using behind a proxy
+## Using behind a Proxy
 
 To do an inspection, this extension requires a connection with the DeepScan server. But this connection cannot be established when you are behind a proxy.
 

--- a/client/src/StatusBar.ts
+++ b/client/src/StatusBar.ts
@@ -64,6 +64,7 @@ export class StatusBar {
             case Status.EMPTY_TOKEN:
             case Status.EXPIRED_TOKEN:
             case Status.INVALID_TOKEN:
+            case Status.SUSPENDED_TOKEN:
                 color = 'darkred';
                 tooltip = 'Inspection failed!';
                 break;

--- a/client/src/deepscanToken.ts
+++ b/client/src/deepscanToken.ts
@@ -42,9 +42,7 @@ export class DeepscanToken {
 
     const generate = 'Generate Token';
     const neverShowAgain = 'Don\'t show again';
-    const message =
-      'An access token is required for using the DeepScan extension. ' +
-      'DeepScan server uses the token to provide reliable and prompt inspection of your code.';
+    const message = 'An access token is required for using the DeepScan extension.';
     const selected = await vscode.window.showWarningMessage(message, generate, neverShowAgain);
     if (selected === generate) {
       const tokenGuideUrl = `${serverUrl}/docs/deepscan/vscode#token`;
@@ -70,6 +68,15 @@ export class DeepscanToken {
     if (selected === regenerate) {
       const tokenRegenerateUrl = `${serverUrl}/dashboard/#view=account-settings`;
       vscode.env.openExternal(vscode.Uri.parse(tokenRegenerateUrl));
+    }
+  }
+
+  async showSuspendedTokenNotification(serverUrl: string) {
+    const goToSite = 'Go to Site';
+    const message = `Your DeepScan access token was suspended. Visit DeepScan site to check your plan in the team settings page.`;
+    const selected = await vscode.window.showErrorMessage(message, goToSite);
+    if (selected === goToSite) {
+      vscode.env.openExternal(vscode.Uri.parse(serverUrl));
     }
   }
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -64,6 +64,9 @@ async function activateClient(context: vscode.ExtensionContext) {
             case Status.INVALID_TOKEN:
                 await deepscanToken.showInvalidTokenNotification(getServerUrl());
                 break;
+            case Status.SUSPENDED_TOKEN:
+                await deepscanToken.showSuspendedTokenNotification(getServerUrl());
+                break;
         }
     }
 
@@ -79,7 +82,7 @@ async function activateClient(context: vscode.ExtensionContext) {
     function showNotificationIfNeeded(params: StatusParams) {
         clearNotification();
 
-        if ([Status.fail, Status.EMPTY_TOKEN, Status.INVALID_TOKEN, Status.EXPIRED_TOKEN].includes(params.state)) {
+        if ([Status.fail, Status.EMPTY_TOKEN, Status.INVALID_TOKEN, Status.EXPIRED_TOKEN, Status.SUSPENDED_TOKEN].includes(params.state)) {
             let message = params.message;
             switch (params.state) {
                 case Status.EMPTY_TOKEN:
@@ -90,6 +93,9 @@ async function activateClient(context: vscode.ExtensionContext) {
                     break;
                 case Status.INVALID_TOKEN:
                     message = 'invalid access token';
+                    break;
+                case Status.SUSPENDED_TOKEN:
+                    message = 'suspended access token';
                     break;
             }
             statusBarMessage = vscode.window.setStatusBarMessage(`A problem occurred communicating with DeepScan server. (${message})`);
@@ -102,7 +108,8 @@ async function activateClient(context: vscode.ExtensionContext) {
     function updateStatusBar(editor: vscode.TextEditor): void {
         const isValidSuffix = editor && _.includes(getSupportedFileSuffixes(getDeepScanConfiguration()), path.extname(editor.document.fileName));
         const status = statusBar.getStatus();
-        const needToShowStatusbar = status === Status.fail || status === Status.EMPTY_TOKEN || status == Status.EXPIRED_TOKEN || status === Status.INVALID_TOKEN;
+        const needToShowStatusbar = status === Status.fail || status === Status.EMPTY_TOKEN || status == Status.EXPIRED_TOKEN
+            || status === Status.INVALID_TOKEN || status === Status.SUSPENDED_TOKEN;
         const show = serverRunning && (needToShowStatusbar || isValidSuffix);
         statusBar.show(show);
     }
@@ -243,7 +250,7 @@ async function activateClient(context: vscode.ExtensionContext) {
             updateStatus(state);
             showNotificationIfNeeded(params);
             activeDecorations.updateDecorations(uri);
-            if (state === Status.INVALID_TOKEN || state == Status.EXPIRED_TOKEN) {
+            if (state === Status.INVALID_TOKEN || state == Status.EXPIRED_TOKEN || state === Status.SUSPENDED_TOKEN) {
                 handleTokenNotification(params);
             }
         });
@@ -338,6 +345,7 @@ async function activateClient(context: vscode.ExtensionContext) {
                 return;
             }
             const Regenerate = 'Regenerate Token';
+            const GoToSite = 'Go to Site';
             const Close = 'Close';
             let message: string;
             let buttons: string[];
@@ -351,6 +359,9 @@ async function activateClient(context: vscode.ExtensionContext) {
                 if (error && error.includes('token') && error.includes('Invalid')) {
                     message = 'Your DeepScan access token is not valid.';
                     buttons = [Regenerate, Close];
+                } else if (error && error.includes('token') && error.includes('Suspended')) {
+                    message = 'Your DeepScan access token was suspended. Visit DeepScan site to check your plan in the team settings page.';
+                    buttons = [GoToSite, Close];
                 } else if (error) {
                     message = `Failed to retrieve token information. (${error})`;
                     buttons = [Close];
@@ -369,6 +380,8 @@ async function activateClient(context: vscode.ExtensionContext) {
             if (selected === Regenerate) {
                 const tokenRegenerateUrl = `${getServerUrl()}/dashboard/#view=account-settings`;
                 vscode.env.openExternal(vscode.Uri.parse(tokenRegenerateUrl));
+            } else if (selected === GoToSite) {
+                vscode.env.openExternal(vscode.Uri.parse(getServerUrl()));
             }
         }),
         vscode.commands.registerCommand(CommandIds.updateToken, async () => {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -19,7 +19,8 @@ export enum Status {
 
     EMPTY_TOKEN = 10,
     INVALID_TOKEN = 11,
-    EXPIRED_TOKEN = 12
+    EXPIRED_TOKEN = 12,
+    SUSPENDED_TOKEN = 13
 }
 
 // "severity" of client.diagnostics. Seems not to comply with the DiagnosticSeverity of language-server.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "version": "1.64.0",
     "author": "DeepScan",
     "publisher": "DeepScan",
+    "pricing": "Trial",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -28,7 +28,8 @@ enum Status {
 
     EMPTY_TOKEN = 10,
     INVALID_TOKEN = 11,
-    EXPIRED_TOKEN = 12
+    EXPIRED_TOKEN = 12,
+    SUSPENDED_TOKEN = 13
 }
 
 interface StatusParams {
@@ -379,6 +380,9 @@ async function inspect(identifier: VersionedTextDocumentIdentifier) {
         } else if (isTokenMessage && message.includes('Invalid')) {
             state = Status.INVALID_TOKEN;
             message = `invalid DeepScan access token. Visit ${generateUrl} to regenerate the token and make sure to copy the correct token string.`;
+        } else if (isTokenMessage && message.includes('Suspended')) {
+            state = Status.SUSPENDED_TOKEN;
+            message = `DeepScan access token was suspended. Visit ${deepscanServer} to check your plan in the team settings page.`;
         }
         connection.console.error(`Failed to inspect: ${message}`);
         connection.sendNotification(StatusNotification.type, {


### PR DESCRIPTION
* Update README.md to clarify that VS Cdoe extension is one of the features of DeepScan Lite/Starter Plan
* Modify notification messages related to VS Code tokens
* Add suspended token type to handle cases where a access token exists but the owner of the token cannot use VS Code Extension