### PR TITLE
Handle the type error about `tooltip` of StatusBarItem

### DIFF
--- a/client/src/StatusBar.ts
+++ b/client/src/StatusBar.ts
@@ -49,7 +49,7 @@ export class StatusBar {
     }
 
     update(status: Status) {
-        let tooltip = this.getTooltip();
+        let tooltip = this.getTooltip() as string;
         let color = '';
         switch (status) {
             case Status.ok:


### PR DESCRIPTION
- Fixed code to handle the type error about `tooltip` of StatusBarItem when running with @type/vscode 1.98